### PR TITLE
Fix street name typo on KB overview map

### DIFF
--- a/maps/map-kb-overview.svg
+++ b/maps/map-kb-overview.svg
@@ -576,6 +576,6 @@
          x="997.30011"
          y="-1171.017"
          style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.5082px;font-family:'Atkinson Hyperlegible';-inkscape-font-specification:'Atkinson Hyperlegible Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;text-anchor:end;fill:#777777;fill-opacity:1;stroke-width:1.02117"
-         id="tspan1541-4-3-2-6-8-1-9">Rue Enile Zola</tspan></text>
+         id="tspan1541-4-3-2-6-8-1-9">Rue Emile Zola</tspan></text>
   </g>
 </svg>


### PR DESCRIPTION
Hi,

This PR fixes a typo on the KB overview map.
However, I did not change the street name to be accented (i.e. '*Émile Zola*').
Should I change it for the accented version ?