### PR TITLE
Remove "Lab ACU" from map

### DIFF
--- a/maps/kb-voltaire-f4.svg
+++ b/maps/kb-voltaire-f4.svg
@@ -123,24 +123,13 @@
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:48.9725px;line-height:0%;font-family:'Atkinson Hyperlegible';-inkscape-font-specification:'Atkinson Hyperlegible Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:#333333;stroke-width:1.2243;stroke-opacity:1"
      x="136.20103"
-     y="372.13254"
+     y="375.10342"
      id="text5325-6-9-2"><tspan
        sodipodi:role="line"
        x="136.20103"
-       y="372.13254"
+       y="375.10342"
        id="tspan5371-2"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:48.9725px;line-height:1.25;font-family:'Atkinson Hyperlegible';-inkscape-font-specification:'Atkinson Hyperlegible Bold';stroke:#333333;stroke-width:1.2243;stroke-opacity:1">KB403</tspan></text>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:43.7605px;line-height:0%;font-family:'Atkinson Hyperlegible';-inkscape-font-specification:'Atkinson Hyperlegible Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:#333333;stroke-width:1.094;stroke-opacity:1"
-     x="123.06465"
-     y="433.64081"
-     id="text5325-6-9-2-8"><tspan
-       sodipodi:role="line"
-       x="123.06465"
-       y="433.64081"
-       id="tspan5371-2-4"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:43.7605px;line-height:1.25;font-family:'Atkinson Hyperlegible';-inkscape-font-specification:'Atkinson Hyperlegible Bold';stroke:#333333;stroke-width:1.094;stroke-opacity:1">Lab ACU</tspan></text>
   <text
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:48.9725px;line-height:0%;font-family:'Atkinson Hyperlegible';-inkscape-font-specification:'Atkinson Hyperlegible Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:#333333;stroke-width:1.2243;stroke-opacity:1"


### PR DESCRIPTION
As the KB 403 room is not an assistants lab anymore (the assistants' lab has been moved to the 2nd floor for both YAKA and ACU), this PR removes the "Lab ACU" mention on the 4th floor map.